### PR TITLE
Fixed negative quantity bug and marketing insert bugs

### DIFF
--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -212,7 +212,7 @@ describe Order do
       @order.line_items.count.should be 0
       @order.add_variant( index_print_variant,  @photo, 1 )
       @order.line_items.count.should be 1
-      @order.finalize!
+      @order.add_marketing_insert
       @order.line_items.count.should be 2
       visible_line_items = @order.line_items.prints.length + @order.line_items.not_prints.length
       visible_line_items.should be 1
@@ -224,11 +224,57 @@ describe Order do
       @order.line_items.count.should be 0
       @order.add_variant( work_order_variant,  @photo, 1 )
       @order.line_items.count.should be 1
-      @order.finalize!
+      @order.add_marketing_insert
       @order.line_items.count.should be 1
       visible_line_items = @order.line_items.prints.length + @order.line_items.not_prints.length
       visible_line_items.should be 1
     end
+
+    it 'should add only ONE  marketing print if order contains IndexPrint products' do
+          index_print_product = Product.taxons_name_eq('index_print').first
+          index_print_variant = index_print_product.variants.first
+          @order.line_items.count.should be 0
+          @order.add_variant( index_print_variant,  @photo, 1 )
+          @order.line_items.count.should be 1
+          @order.add_marketing_insert
+          @order.line_items.count.should be 2
+          @order.add_marketing_insert
+          @order.line_items.count.should be 2
+          marketing_insert = @order.line_items.find_by_hidden(true)
+          marketing_insert.quantity = 10
+          marketing_insert.save
+          @order.add_marketing_insert
+          @order.line_items.count.should be 2
+          marketing_insert = @order.line_items.find_by_hidden(true)
+          marketing_insert.quantity.should be 1
+
+          visible_line_items = @order.line_items.prints.length + @order.line_items.not_prints.length
+          visible_line_items.should be 1
+    end
+
+    it 'should remove marketing print line_item if order no longer contains IndexPrint products' do
+          index_print_product = Product.taxons_name_eq('index_print').first
+          index_print_variant = index_print_product.variants.first
+          @order.line_items.count.should be 0
+          index_print_line_item = @order.add_variant( index_print_variant,  @photo, 1 )
+          @order.line_items.count.should be 1
+          work_order_product = Product.taxons_name_eq('work_order').first
+          work_order_variant = work_order_product.variants.first
+          @order.add_variant( work_order_variant,  @photo, 1 )
+          @order.line_items.count.should be 2
+          @order.add_marketing_insert
+          @order.line_items.count.should be 3
+          visible_line_items = @order.line_items.prints.length + @order.line_items.not_prints.length
+          visible_line_items.should be 2
+          index_print_line_item.destroy
+          @order.reload
+          @order.line_items.count.should be 2
+          visible_line_items = @order.line_items.prints.length + @order.line_items.not_prints.length
+          visible_line_items.should be 1
+          @order.add_marketing_insert  #removes marketing print because index product has been removed
+          @order.line_items.count.should be 1
+        end
+
 
     it 'should send order confirmed email' do
       resque_jobs(:except => [ZZ::Async::MailingListSync]) do

--- a/spree_core-0.60.1/lib/spree_core/railtie.rb
+++ b/spree_core-0.60.1/lib/spree_core/railtie.rb
@@ -15,14 +15,14 @@ module SpreeCore
         [
           Gateway::Braintree,
           Gateway::Bogus,
-          Gateway::AuthorizeNet,
-          Gateway::AuthorizeNetCim,
-          Gateway::Eway,
-          Gateway::Linkpoint,
-          Gateway::PayPal,
-          Gateway::SagePay,
-          Gateway::Beanstream,
-          PaymentMethod::Check
+          #Gateway::AuthorizeNet,
+          #Gateway::AuthorizeNetCim,
+          #Gateway::Eway,
+          #Gateway::Linkpoint,
+          #Gateway::PayPal,
+          #Gateway::SagePay,
+          #Gateway::Beanstream,
+          #PaymentMethod::Check
         ].each{|gw|
           begin
             gw.register
@@ -33,12 +33,12 @@ module SpreeCore
 
         #register all calculators
         [
-          Calculator::FlatPercentItemTotal,
-          Calculator::FlatRate,
-          Calculator::FlexiRate,
-          Calculator::PerItem,
+          #Calculator::FlatPercentItemTotal,
+          #Calculator::FlatRate,
+          #Calculator::FlexiRate,
+          #Calculator::PerItem,
           Calculator::SalesTax,
-          Calculator::Vat,
+          #Calculator::Vat,
           Calculator::EzpShipping
           #Calculator::PriceBucket
         ].each{|c_model|

--- a/spree_zangzing/app/models/order_decorator.rb
+++ b/spree_zangzing/app/models/order_decorator.rb
@@ -923,7 +923,7 @@ Have a wonderful time sharing photos! And, we hope you think of us and visit www
   def delete_line_items_at_zero
     # change the line item counts
     LineItem.delete_all( [ "quantity <= 0 AND order_id = ?", self.id] )
-    self.line_items.order(:id).reload
+    self.reload
   end
 
   def cart_count

--- a/spree_zangzing/app/models/order_decorator.rb
+++ b/spree_zangzing/app/models/order_decorator.rb
@@ -922,8 +922,8 @@ Have a wonderful time sharing photos! And, we hope you think of us and visit www
 
   def delete_line_items_at_zero
     # change the line item counts
-    LineItem.delete_all( [ "quantity <= 0 AND order_id = ?", self.id] )
-    self.reload
+    deleted = LineItem.delete_all( [ "quantity <= 0 AND order_id = ?", self.id] )
+    self.reload if deleted > 0 
   end
 
   def cart_count

--- a/spree_zangzing/app/models/order_decorator.rb
+++ b/spree_zangzing/app/models/order_decorator.rb
@@ -73,6 +73,7 @@ Order.class_eval do
 
       transition :from => 'confirm',  :to => 'complete'
     end
+    before_transition :to => 'confirm',  :do => :add_marketing_insert
     before_transition :to => 'confirm',  :do => :create_tax_charge!
     before_transition :to => 'confirm',  :do => :assign_default_shipping_method
     after_transition  :to => 'confirm',  :do => :create_default_shipment!
@@ -419,7 +420,6 @@ Order.class_eval do
     # lock any optional adjustments (coupon promotions, etc.)
     adjustments.optional.each { |adjustment| adjustment.update_attribute("locked", true) }
 
-    add_marketing_insert
 
     ZZ::Async::Email.enqueue( :order_confirmed, self.id )
 
@@ -451,20 +451,32 @@ Order.class_eval do
 
   def add_marketing_insert
     index_print_product_ids = Product.taxons_name_eq('index_print').map{|p| p.id }
-    if line_items.detect { |li| index_print_product_ids.include? li.variant.product_id }
-      variant = Variant.find_by_id( Order::MKTG_INSERT_VARIANT_ID )
-      photo = ez.marketing_insert( Order::MKTG_INSERT_USER_NAME, Order::MKTG_INSERT_ALBUM_NAME)
-      if variant && photo
-        li = LineItem.new()
-        li.quantity = 1
-        li.price    = 0.0
-        li.variant  = variant
-        li.photo    = photo
-        li.hidden   = true
-        self.line_items << li
+    variant = Variant.find_by_id( Order::MKTG_INSERT_VARIANT_ID )
+    if visible_line_items.detect { |li| index_print_product_ids.include? li.variant.product_id }
+      # The cart contains prints, add a new marketing insert or
+      # make sure the existing marketing insert's quantity is one
+      if existing_insert = line_items.find_by_hidden_and_variant_id(true, variant.id)
+        existing_insert.quantity = 1
+        existing_insert.save
       else
-        Rails.logger.error( "MARKETING INSERT ERROR: Variant with id=#{Order::MKTG_INSERT_VARIANT_ID} not found") if variant.nil?
-        Rails.logger.error( "MARKETING INSERT ERROR: No marketing insert image found. Looking in user=#{Order::MKTG_INSERT_USER_NAME} album=#{Order::MKTG_INSERT_ALBUM_NAME}") if photo.nil?
+        photo = ez.marketing_insert( Order::MKTG_INSERT_USER_NAME, Order::MKTG_INSERT_ALBUM_NAME)
+        if variant && photo
+          li = LineItem.new()
+          li.quantity = 1
+          li.price    = 0.0
+          li.variant  = variant
+          li.photo    = photo
+          li.hidden   = true
+          self.line_items << li
+        else
+          Rails.logger.error( "MARKETING INSERT ERROR: Variant with id=#{Order::MKTG_INSERT_VARIANT_ID} not found") if variant.nil?
+          Rails.logger.error( "MARKETING INSERT ERROR: No marketing insert image found. Looking in user=#{Order::MKTG_INSERT_USER_NAME} album=#{Order::MKTG_INSERT_ALBUM_NAME}") if photo.nil?
+        end
+      end
+    else
+      # The cart does not contains prints, make sure there is no marketing print
+      if existing_insert = line_items.find_by_hidden_and_variant_id(true, variant.id)
+        existing_insert.destroy
       end
     end
   end
@@ -910,7 +922,7 @@ Have a wonderful time sharing photos! And, we hope you think of us and visit www
 
   def delete_line_items_at_zero
     # change the line item counts
-    LineItem.delete_all(:quantity => 0, :order_id => self.id)
+    LineItem.delete_all( [ "quantity <= 0 AND order_id = ?", self.id] )
     self.line_items.order(:id).reload
   end
 


### PR DESCRIPTION
The issue is that you can update a line item in the cart to have a negative quantity thus lowering the cart subtotal to a minimum of zero a.k.a "Buy anything you want, pay whatever you want".

The issue was introduced by the much needed performance update. While before whenever the order was updated all line_items with quantities smaller or equal to 0 were deleted. In the improved version only line items with quantities equal to zero were removed from the order on update, the change was replacing an "equals" with a "lesser than or equals".

I also took the opportunity to insert the marketing print before the final shipping is calculated. When the final total is calculated the marketing print is added/removed as needed and its quantity is set to 1 (an update in the cart may also update the number of marketing prints because they use the same variant id)

Specs were added to confirm marketing print behavior
