### PR TITLE
Gws memcache

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -917,7 +917,7 @@ class Photo < ActiveRecord::Base
   # we invalidate the browsers cache for
   # old items.
   def self.hash_schema_version
-    'v6'
+    'v7'
   end
 
   # this method packages up the fields

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,8 +43,8 @@ Server::Application.configure do
 
 
   # set up cache manager
-  #CacheWrapper.initialize_cache(config, 1.5)
-  ActionController::Base.cache_store = :memory_store
+  #CacheWrapper.initialize_cache(:mem_cache_store, config, 1.5)
+  CacheWrapper.initialize_cache(:memory_store, config, 1.5)
 
   # mail logger is too verbose, shut it off
   config.action_mailer.logger = nil

--- a/config/environments/photos_production.rb
+++ b/config/environments/photos_production.rb
@@ -42,7 +42,7 @@ Server::Application.configure do
   config.bench_test_allowed = false
 
   # set up to use memcached
-  CacheWrapper.initialize_cache(config, 1.5)
+  CacheWrapper.initialize_cache(:mem_cache_store, config, 1.5)
 
   # mail logger is too verbose, shut it off
   config.action_mailer.logger = nil

--- a/config/environments/photos_staging.rb
+++ b/config/environments/photos_staging.rb
@@ -39,7 +39,7 @@ Server::Application.configure do
   config.bench_test_allowed = true
 
   # use memcached
-  CacheWrapper.initialize_cache(config, 1.5)
+  CacheWrapper.initialize_cache(:mem_cache_store, config, 1.5)
 
   # mail logger is too verbose, shut it off
   config.action_mailer.logger = nil

--- a/config/initializers/mem_cache_performance_patch.rb
+++ b/config/initializers/mem_cache_performance_patch.rb
@@ -1,0 +1,91 @@
+##
+# A Ruby client library for memcached.
+#
+
+class MemCache
+  def nowait(key)
+    server = get_server_for_key(key)
+    server.nowait
+  end
+
+  protected unless $TESTING
+
+  ##
+  # Gets or creates a socket connected to the given server, and yields it
+  # to the block, wrapped in a mutex synchronization if @multithread is true.
+  #
+  # If a socket error (SocketError, SystemCallError, IOError) or protocol error
+  # (MemCacheError) is raised by the block, closes the socket, attempts to
+  # connect again, and retries the block (once).  If an error is again raised,
+  # reraises it as MemCacheError.
+  #
+  # If unable to connect to the server (or if in the reconnect wait period),
+  # raises MemCacheError.  Note that the socket connect code marks a server
+  # dead for a timeout period, so retrying does not apply to connection attempt
+  # failures (but does still apply to unexpectedly lost connections etc.).
+
+  def with_socket_management(server, &block)
+    check_multithread_status!
+
+    @mutex.lock if @multithread
+    retried = false
+
+    begin
+      socket = server.socket
+
+      # Raise an IndexError to show this server is out of whack. If were inside
+      # a with_server block, we'll catch it and attempt to restart the operation.
+
+      raise IndexError, "No connection to server (#{server.status})" if socket.nil?
+
+      block.call(socket)
+
+    rescue SocketError, Errno::EAGAIN => err
+      logger.warn { "Socket failure: #{err.message}" } if logger
+      server.mark_dead(err)
+      handle_error(server, err)
+
+    rescue MemCacheError, SystemCallError, IOError, Timeout::Error => err
+      logger.warn { "Generic failure: #{err.class.name}: #{err.message}" } if logger
+      handle_error(server, err) if retried || socket.nil?
+      retried = true
+      retry
+    end
+  ensure
+    @mutex.unlock if @multithread
+  end
+
+
+  ##
+  # This class represents a memcached server instance.
+
+  class Server
+
+    ##
+    # The amount of time to wait before attempting to re-establish a
+    # connection with a server that is marked dead.
+
+    RETRY_DELAY = 5.0
+
+
+    ##
+    # Mark the server as dead and close its socket.
+
+    def mark_dead(error)
+      close
+      @retry  = Time.now + RETRY_DELAY
+
+      reason = "#{error.class.name}: #{error.message}"
+      @status = sprintf "%s:%s DEAD (%s), will retry at %s", @host, @port, reason, @retry
+      @logger.info { @status } if @logger
+    end
+
+    # don't make us wait to try again
+    def nowait
+      @retry = nil
+    end
+
+  end
+
+
+end

--- a/config/initializers/mem_cache_performance_patch.rb
+++ b/config/initializers/mem_cache_performance_patch.rb
@@ -14,7 +14,7 @@ class MemCache
   # Gets or creates a socket connected to the given server, and yields it
   # to the block, wrapped in a mutex synchronization if @multithread is true.
   #
-  # If a socket error (SocketError, SystemCallError, IOError) or protocol error
+  # If a socket error (SocketError, SystemCallError, IOError, Timeout) or protocol error
   # (MemCacheError) is raised by the block, closes the socket, attempts to
   # connect again, and retries the block (once).  If an error is again raised,
   # reraises it as MemCacheError.
@@ -67,18 +67,6 @@ class MemCache
 
     RETRY_DELAY = 5.0
 
-
-    ##
-    # Mark the server as dead and close its socket.
-
-    def mark_dead(error)
-      close
-      @retry  = Time.now + RETRY_DELAY
-
-      reason = "#{error.class.name}: #{error.message}"
-      @status = sprintf "%s:%s DEAD (%s), will retry at %s", @host, @port, reason, @retry
-      @logger.info { @status } if @logger
-    end
 
     # don't make us wait to try again
     def nowait

--- a/config/memcached.yml
+++ b/config/memcached.yml
@@ -3,4 +3,5 @@
 # about are the servers, the rest is unused.
 defaults:
   servers:
+      #- 192.168.1.164:11211
       - localhost:11211

--- a/lib/cache/album/loader.rb
+++ b/lib/cache/album/loader.rb
@@ -239,7 +239,7 @@ module Cache
       # we invalidate the browsers cache for
       # old items.
       def self.hash_schema_version
-        'v7'
+        'v8'
       end
 
       # this method returns the album as a map which allows us to perform

--- a/lib/cache_wrapper.rb
+++ b/lib/cache_wrapper.rb
@@ -58,7 +58,7 @@ class CacheWrapper
       opts = {}
       #todo, after debugging comment out logger line
       opts[:logger] = config.logger
-      opts[:timeout] = 1.5
+      opts[:timeout] = timeout
       # bypass rails wrappers
       @@cache = MemCacheWrapper.new(MemCache.new(MemcachedConfig.server_list, opts))
     else

--- a/lib/cache_wrapper.rb
+++ b/lib/cache_wrapper.rb
@@ -25,9 +25,7 @@ class CacheWrapper
         # verify it
         check_data = cache.read(key)
         write_ok = value == check_data
-        if write_ok == false
-          Rails.logger.error("Memcache write with verify attempt: #{attempt+1} failed for key: #{key}")
-        end
+        Rails.logger.error("Memcache write with verify attempt: #{attempt+1} failed for key: #{key}") unless write_ok
       end
       break if write_ok
     end
@@ -86,7 +84,7 @@ class MemCacheWrapper
       expires_in ||= 0
       result = @cache.set(key, value, expires_in, true)
     end
-    result.nil? ? false : true
+    !result.nil?  # if nil return false, true otherwise
   end
 
   def read(key)
@@ -102,7 +100,7 @@ class MemCacheWrapper
     safe_wrap do
       result = @cache.delete(key)
     end
-    result.nil? ? false : true
+    !result.nil?  # if nil return false, true otherwise
   end
 
   # if server is dead, mark as undead so we

--- a/lib/cache_wrapper.rb
+++ b/lib/cache_wrapper.rb
@@ -58,6 +58,7 @@ class CacheWrapper
     @@cache = nil
     if cache_type == :mem_cache_store
       opts = {}
+      #todo, after debugging comment out logger line
       opts[:logger] = config.logger
       opts[:timeout] = 1.5
       # bypass rails wrappers


### PR DESCRIPTION
Improves memcached client behavior by extending timeout from 0.5 to 1.5, decreasing dead time to 5 seconds from 30, bypasses rails wrappers which do unnecessary local caching on top of memcached, adds verify mode for writes where we try 2 times to write with validation that the result is really in memcached.  Treats network timeout error as a re-triable condition.

Will be deploying directly to production since easier to reproduce issues with many machines.
